### PR TITLE
Update mappings for version 8.4

### DIFF
--- a/lib/mappings.json
+++ b/lib/mappings.json
@@ -419,6 +419,109 @@
       "bank_zip_code",
       "beginning_image_number"
     ],
+    "^8.4": [
+      "form_type",
+      "filer_committee_id_number",
+      "change_of_committee_name",
+      "committee_name",
+      "change_of_address",
+      "street_1",
+      "street_2",
+      "city",
+      "state",
+      "zip_code",
+      "change_of_committee_email",
+      "committee_email",
+      "change_of_committee_url",
+      "committee_url",
+      "effective_date",
+      "signature_last_name",
+      "signature_first_name",
+      "signature_middle_name",
+      "signature_prefix",
+      "signature_suffix",
+      "date_signed",
+      "committee_type",
+      "candidate_id_number",
+      "candidate_last_name",
+      "candidate_first_name",
+      "candidate_middle_name",
+      "candidate_prefix",
+      "candidate_suffix",
+      "candidate_office",
+      "candidate_state",
+      "candidate_district",
+      "party_code",
+      "party_type",
+      "organization_type",
+      "lobbyist_registrant_pac",
+      "lobbyist_registrant_pac_2",
+      "leadership_pac",
+      "lobbyist_registrant_pac_3",
+      "lobbyist_registrant_pac_4",
+      "affiliated_committee_id_number",
+      "affiliated_committee_name",
+      "affiliated_candidate_id_number",
+      "affiliated_last_name",
+      "affiliated_first_name",
+      "affiliated_middle_name",
+      "affiliated_prefix",
+      "affiliated_suffix",
+      "affiliated_street_1",
+      "affiliated_street_2",
+      "affiliated_city",
+      "affiliated_state",
+      "affiliated_zip_code",
+      "affiliated_relationship_code",
+      "custodian_last_name",
+      "custodian_first_name",
+      "custodian_middle_name",
+      "custodian_prefix",
+      "custodian_suffix",
+      "custodian_street_1",
+      "custodian_street_2",
+      "custodian_city",
+      "custodian_state",
+      "custodian_zip_code",
+      "custodian_title",
+      "custodian_telephone",
+      "treasurer_last_name",
+      "treasurer_first_name",
+      "treasurer_middle_name",
+      "treasurer_prefix",
+      "treasurer_suffix",
+      "treasurer_street_1",
+      "treasurer_street_2",
+      "treasurer_city",
+      "treasurer_state",
+      "treasurer_zip_code",
+      "treasurer_title",
+      "treasurer_telephone",
+      "agent_last_name",
+      "agent_first_name",
+      "agent_middle_name",
+      "agent_prefix",
+      "agent_suffix",
+      "agent_street_1",
+      "agent_street_2",
+      "agent_city",
+      "agent_state",
+      "agent_zip_code",
+      "agent_title",
+      "agent_telephone",
+      "bank_name",
+      "bank_street_1",
+      "bank_street_2",
+      "bank_city",
+      "bank_state",
+      "bank_zip_code",
+      "bank2_name",
+      "bank2_street_1",
+      "bank2_street_2",
+      "bank2_city",
+      "bank2_state",
+      "bank2_zip_code"
+    ],
     "^8.3|8.2|8.1|8.0|7.0|6.4": [
       "form_type",
       "filer_committee_id_number",
@@ -866,7 +969,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -957,7 +1060,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -1045,7 +1148,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -1232,7 +1335,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -1456,7 +1559,7 @@
       "bank_zip_code",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
       "filer_committee_id_number",
       "joint_fund_participant_committee_name",
@@ -1696,7 +1799,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2": [
+    "^8.4|8.3|8.2": [
       "form_type",
       "candidate_id_number",
       "candidate_last_name",
@@ -1937,7 +2040,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "report_type",
@@ -2299,7 +2402,7 @@
       "col_b_gross_receipts_minus_personal_funds_general",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -2765,7 +2868,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -3006,7 +3109,7 @@
       "end_image_number",
       "receipt_date"
     ],
-    "^8.3|8.2|8.1|8.0|7.0": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -3820,7 +3923,7 @@
     ]
   },
   "^f3p31": {
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -3915,7 +4018,7 @@
     ]
   },
   "^f3ps": {
-    "^8.3|8.2|8.1|8.0|7.0": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0": [
       "form_type",
       "filer_committee_id_number",
       "date_general_election",
@@ -4259,7 +4362,7 @@
       "total_disbursements",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "date_general_election",
@@ -4587,7 +4690,7 @@
       "col_b_net_operating_expenditures",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -5311,7 +5414,7 @@
       "col_b_total_disbursements",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -5783,7 +5886,7 @@
       "contributor_occupation",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -5868,7 +5971,7 @@
       "election_other_description",
       "image_number"
     ],
-    "^8.3|8.2|8.1": [
+    "^8.4|8.3|8.2|8.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -6112,7 +6215,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "original_amendment_date",
@@ -6201,7 +6304,7 @@
       "contribution_amount",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -6306,7 +6409,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "organization_name",
@@ -6372,7 +6475,7 @@
       "communication_cost",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -6761,7 +6864,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.3": [
+    "^8.4|8.3": [
       "form_type",
       "filer_committee_id_number",
       "entity_type",
@@ -6949,7 +7052,7 @@
       "controller_occupation",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7015,7 +7118,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7203,7 +7306,7 @@
       "transaction_id",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7376,7 +7479,7 @@
       "back_reference_tran_id_number",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7418,7 +7521,7 @@
       "end_image_number",
       "receipt_date"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -7593,7 +7696,7 @@
       "public_communications_referencing_party_ratio_applies",
       "image_number"
     ],
-    "^8.3|8.2": [
+    "^8.4|8.3|8.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7742,7 +7845,7 @@
       "nonfederal_percentage",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7792,7 +7895,7 @@
       "event_activity_name",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7895,7 +7998,7 @@
       "total_amount",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -8147,7 +8250,7 @@
       "generic_campaign_amount",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -8230,7 +8333,7 @@
       "total_amount",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -8419,7 +8522,7 @@
       "increased_limit_code",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -8789,7 +8892,7 @@
       "reference_code",
       "increased_limit_code"
     ],
-    "^3|^2": [
+    "^3": [
       "form_type",
       "filer_committee_id_number",
       "entity_type",
@@ -8828,6 +8931,44 @@
       "back_reference_sched_name",
       "reference_code"
     ],
+    "^2": [
+      "form_type",
+      "filer_committee_id_number",
+      "entity_type",
+      "contributor_name",
+      "contributor_street_1",
+      "contributor_street_2",
+      "contributor_city",
+      "contributor_state",
+      "contributor_zip_code",
+      "election_code",
+      "election_other_description",
+      "contributor_employer",
+      "contributor_occupation",
+      "contribution_aggregate",
+      "contribution_date",
+      "contribution_amount",
+      "contribution_purpose_code",
+      "contribution_purpose_descrip",
+      "donor_committee_fec_id",
+      "donor_candidate_fec_id",
+      "donor_candidate_name",
+      "donor_candidate_office",
+      "donor_candidate_state",
+      "donor_candidate_district",
+      "conduit_name",
+      "conduit_street1",
+      "conduit_street2",
+      "conduit_city",
+      "conduit_state",
+      "conduit_zip_code",
+      "memo_code",
+      "memo_text_description",
+      "amended_cd",
+      "transaction_id",
+      "back_reference_tran_id_number",
+      "back_reference_sched_name"
+    ],
     "^1": [
       "form_type",
       "filer_committee_id_number",
@@ -8864,7 +9005,7 @@
     ]
   },
   "^sa3l": {
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -9128,7 +9269,7 @@
       "refund_or_disposal_of_excess",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -9595,7 +9736,7 @@
       "secured",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -9774,7 +9915,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -9823,7 +9964,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -9857,7 +9998,7 @@
       "authorized_date",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -9873,7 +10014,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -9923,7 +10064,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -9965,7 +10106,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -10007,7 +10148,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -10049,7 +10190,7 @@
       "loan_incurred_date",
       "loan_due_date",
       "loan_restructured",
-      "loan_inccured_date_original",
+      "loan_incurred_date_original",
       "credit_amount_this_draw",
       "total_balance",
       "others_liable",
@@ -10094,7 +10235,7 @@
       "guaranteed_amount",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10178,7 +10319,7 @@
       "balance_at_close_this_period",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10396,7 +10537,7 @@
       "date_signed",
       "image_number"
     ],
-    "^8.3|8.2|8.1": [
+    "^8.4|8.3|8.2|8.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10855,7 +10996,7 @@
       "increased_limit",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0": [
+    "^8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -11249,7 +11390,7 @@
       "col_b_cash_on_hand_close_of_period",
       "image_number"
     ],
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -11337,7 +11478,7 @@
     ]
   },
   "^text": {
-    "^8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "rec_type",
       "filer_committee_id_number",
       "transaction_id_number",


### PR DESCRIPTION
Relevant updates from `fech-sources`: https://github.com/dwillis/fech-sources/commit/f51f34a7355b4261c2b3b7ea8ed87bcb1ddc2864

Also fixed a typo for `loan_inccured_date_original`.