### PR TITLE
fix a few oversights with v8.4 mappings

### DIFF
--- a/lib/renderedMaps.js
+++ b/lib/renderedMaps.js
@@ -5162,7 +5162,7 @@ export default {
     ]
   },
   "^f3z1": {
-    "^(P3.4|8.3|8.2)": [
+    "^(P3.4|8.4|8.3|8.2)": [
       "form_type",
       "filer_committee_id_number",
       "principal_committee_name",
@@ -5202,7 +5202,7 @@ export default {
     ]
   },
   "^f3z2": {
-    "^(P3.4|8.3|8.2)": [
+    "^(P3.4|8.4|8.3|8.2)": [
       "form_type",
       "filer_committee_id_number",
       "principal_committee_name",
@@ -5716,7 +5716,7 @@ export default {
       "date_signed",
       "beginning_image_number"
     ],
-    "^(8.3|8.2|8.1)": [
+    "^(8.4|8.3|8.2|8.1)": [
       "form_type",
       "filer_committee_id_number",
       "entity_type",


### PR DESCRIPTION
This PR fixes a few oversights from https://github.com/PublicI/fec-parse/pull/16

- Fixes F3Z1 and F3Z2 ([fecfile PR](https://github.com/esonderegger/fecfile/pull/29))
- Fixes F5 ([fecfile PR](https://github.com/esonderegger/fecfile/pull/32))